### PR TITLE
remove unnecessary include files from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,7 @@
 		}
     },
     "extra": {
-        "class": "Yurun\\Util\\Swoole\\Guzzle\\Plugin\\Plugin",
-        "include_files": [
-            "src/load.php",
-            "src/functions.php"
-        ]
+        "class": "Yurun\\Util\\Swoole\\Guzzle\\Plugin\\Plugin"
     },
     "scripts": {
         "post-autoload-dump": [


### PR DESCRIPTION
Those files raise exception when using with Guzzle: 
Fatal error: Cannot redeclare GuzzleHttp\uri_template() (previously declared in /var/www/weather/vendor/guzzlehttp/guzzle/src/functions.php:17) in /var/www/weather/vendor/yurunsoft/guzzle-swoole/src/load.php on line 31